### PR TITLE
image comment immutable default value

### DIFF
--- a/mrtrix3/io/image.py
+++ b/mrtrix3/io/image.py
@@ -30,12 +30,12 @@ class Image (object):
 
     def __init__(self, data=None, vox=(),
                        transform=np.eye(4),
-                       grad=None, comments=[]):
+                       grad=None, comments=None):
         self.data = data
         self.vox = vox
         self.transform = transform
         self.grad = grad
-        self.comments = comments
+        self.comments = comments if comments is not None else []
 
 
     _array_attr = ['shape', 'ndim', 'dtype', 'size', 'strides', 'nbytes']


### PR DESCRIPTION
fixes:
```python
In [1]: from mrtrix3.io import load_mrtrix
In [2]: im = load_mrtrix('/Users/mp/data/1.mif')
In [3]: im.comments
Out[3]: ['resliced using warp image "warp.mif"']
In [4]: im = load_mrtrix('/Users/mp/data/1.mif')
In [5]: im.comments
Out[5]: ['resliced using warp image "warp.mif"',
 'resliced using warp image "warp.mif"']
```